### PR TITLE
Creates a directory for UI documentation

### DIFF
--- a/draftivist_ui/docs/ui_accessibility.md
+++ b/draftivist_ui/docs/ui_accessibility.md
@@ -1,0 +1,5 @@
+## UI Accessibility Guide
+Documentation for accessibility best practices and  how Draftivist plan's to adhere to said best practices.
+
+### Resources
+- [5 Accessibility Concerns](https://bighack.org/5-most-annoying-website-features-i-face-as-a-blind-screen-reader-user-accessibility/)


### PR DESCRIPTION
### Description
- Creates a `docs` directory in the `draftivist-ui` directory to act as a Wiki replacement
- Adds `UI Accessibility Guide` to the `docs` directory


As part of #16 