### PR TITLE
Admin Look and Feel change

### DIFF
--- a/draftivist_api/cyoa/settings.py
+++ b/draftivist_api/cyoa/settings.py
@@ -35,12 +35,14 @@ ALLOWED_HOSTS = ['*']
 # Application definition
 
 INSTALLED_APPS = [
+    'jazzmin',
     'django.contrib.admin',
     'django.contrib.auth',
     'django.contrib.contenttypes',
     'django.contrib.sessions',
     'django.contrib.messages',
     'django.contrib.staticfiles',
+    'django.contrib.admindocs',
     'rest_framework',
     'corsheaders',
     'api'
@@ -140,3 +142,126 @@ CORS_ALLOW_CREDENTIALS = True
 CORS_ORIGIN_WHITELIST = [
     'http://localhost:3000',
 ]
+
+JAZZMIN_SETTINGS = {
+    # title of the window
+    "site_title": "Draftivist",
+
+    # Title on the brand, and the login screen (19 chars max)
+    "site_header": "Draftivist",
+
+    # square logo to use for your site, must be present in static files, used for favicon and brand on top left
+    # "site_logo": "img/logo.png",
+
+    # Welcome text on the login screen
+    "welcome_sign": "Draftivist Campaign Management",
+
+    # Copyright on the footer
+    # "copyright": "Acme Library Ltd",
+
+    # The model admin to search from the search bar, search bar omitted if excluded
+    # "search_model": "api.Campaign",
+
+    # Field name on user model that contains avatar image
+    "user_avatar": None,
+
+    ############
+    # Top Menu #
+    ############
+
+    # Links to put along the top menu
+    # "topmenu_links": [
+
+    #     # Url that gets reversed (Permissions can be added)
+    #     {"name": "Home",  "url": "admin:index", "permissions": ["auth.view_user"]},
+
+    #     # external url that opens in a new window (Permissions can be added)
+    #     {"name": "Support", "url": "https://github.com/farridav/django-jazzmin/issues", "new_window": True},
+
+    #     # model admin to link to (Permissions checked against model)
+    #     {"model": "auth.User"},
+
+    #     # App with dropdown menu to all its models pages (Permissions checked against models)
+    #     {"app": "books"},
+    # ],
+
+    #############
+    # User Menu #
+    #############
+
+    # Additional links to include in the user menu on the top right ("app" url type is not allowed)
+    "usermenu_links": [
+        {"name": "Support", "url": "https://github.com/farridav/django-jazzmin/issues", "new_window": True},
+        {"model": "auth.user"}
+    ],
+
+    #############
+    # Side Menu #
+    #############
+
+    # Whether to display the side menu
+    "show_sidebar": True,
+
+    # Whether to aut expand the menu
+    "navigation_expanded": True,
+
+    # Hide these apps when generating side menu e.g (auth)
+    "hide_apps": [],
+
+    # Hide these models when generating side menu (e.g auth.user)
+    "hide_models": [],
+
+    # List of apps (and/or models) to base side menu ordering off of (does not need to contain all apps/models)
+    # "order_with_respect_to": ["auth", "api"],
+
+    # Custom links to append to app groups, keyed on app name
+    # "custom_links": {
+    #     "books": [{
+    #         "name": "Make Messages", 
+    #         "url": "make_messages", 
+    #         "icon": "fas fa-comments",
+    #         "permissions": ["books.view_book"]
+    #     }]
+    # },
+
+    # Custom icons for side menu apps/models See https://fontawesome.com/icons?d=gallery&m=free
+    # for a list of icon classes
+    "icons": {
+        "auth": "fas fa-users-cog",
+        "auth.user": "fas fa-user",
+        "auth.Group": "fas fa-users",
+    },
+    # Icons that are used when one is not manually specified
+    "default_icon_parents": "fas fa-chevron-circle-right",
+    "default_icon_children": "fas fa-circle",
+
+    #################
+    # Related Modal #
+    #################
+    # Use modals instead of popups
+    "related_modal_active": False,
+
+    #############
+    # UI Tweaks #
+    #############
+    # Relative paths to custom CSS/JS scripts (must be present in static files)
+    "custom_css": None,
+    "custom_js": None,
+    # Whether to show the UI customizer on the sidebar
+    "show_ui_builder": False,
+
+    ###############
+    # Change view #
+    ###############
+    # Render out the change view as a single form, or in tabs, current options are
+    # - single
+    # - horizontal_tabs (default)
+    # - vertical_tabs
+    # - collapsible
+    # - carousel
+    "changeform_format": "horizontal_tabs",
+    # override change forms on a per modeladmin basis
+    "changeform_format_overrides": {"auth.user": "collapsible", "auth.group": "vertical_tabs",},
+    # Add a language dropdown into the admin
+    "language_chooser": True,
+}

--- a/draftivist_api/cyoa/urls.py
+++ b/draftivist_api/cyoa/urls.py
@@ -42,4 +42,6 @@ router.register(r'member', MemberViewSet)
 urlpatterns = [
     path('', include(router.urls)),
     path('admin/', admin.site.urls),
+    path('admin/doc/', include('django.contrib.admindocs.urls')),
+    # path('accounts/', include('django.contrib.auth.urls')), # is this needed?
 ]

--- a/draftivist_api/requirements.txt
+++ b/draftivist_api/requirements.txt
@@ -2,4 +2,5 @@ python-dotenv==0.14.0
 Django==3.0.8
 django-cors-headers==3.4.0
 djangorestframework==3.11.0
+django-jazzmin==2.4.1
 psycopg2==2.8.6


### PR DESCRIPTION
https://django-jazzmin.readthedocs.io/

installed the above admin skin library. Looks alright. There's options for custom css and stuff too

just an option, there's others as well, or we could use the default

<img width="1438" alt="Screen Shot 2020-11-29 at 6 38 20 PM" src="https://user-images.githubusercontent.com/10520187/100557433-2baa2500-3277-11eb-9d44-ce761c749a58.png">
